### PR TITLE
Fix: 'MockApp' object has no attribute 'config'

### DIFF
--- a/flask_session_cookie_manager2.py
+++ b/flask_session_cookie_manager2.py
@@ -26,6 +26,7 @@ class MockApp(object):
 
     def __init__(self, secret_key):
         self.secret_key = secret_key
+        self.config = {"SECRET_KEY_FALLBACKS": None}
 
 
 class FSCM:

--- a/flask_session_cookie_manager3.py
+++ b/flask_session_cookie_manager3.py
@@ -26,6 +26,7 @@ class MockApp(object):
 
     def __init__(self, secret_key):
         self.secret_key = secret_key
+        self.config = {"SECRET_KEY_FALLBACKS": None}
 
 
 if sys.version_info[0] == 3 and sys.version_info[1] < 4: # >= 3.0 && < 3.4


### PR DESCRIPTION
When I try to use this script, an error occurred: 'MockApp' object has no attribute 'config'.

I find that there is something changed in get_signing_serializer().

```python
if fallbacks := app.config["SECRET_KEY_FALLBACKS"]:
    keys.extend(fallbacks)
```